### PR TITLE
Add initial test coverage (fails on tail values)

### DIFF
--- a/StreamVByte.Tests/StreamVByte.Tests.csproj
+++ b/StreamVByte.Tests/StreamVByte.Tests.csproj
@@ -21,4 +21,12 @@
     </PackageReference>
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\StreamVByte\StreamVByte.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
 </Project>

--- a/StreamVByte.Tests/StreamVByteTests.cs
+++ b/StreamVByte.Tests/StreamVByteTests.cs
@@ -1,0 +1,35 @@
+﻿namespace StreamVByteImpl.Tests;
+
+public class StreamVByteTests
+{
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)] // fails
+    [InlineData(16)]
+    [InlineData(17)] // fails
+    [InlineData(32)]
+    [InlineData(64)]
+    [InlineData(128)]
+    [InlineData(256)]
+    [InlineData(512)]
+    [InlineData(513)] // fails
+    public void CanRoundtrip(uint count)
+    {
+        var source = new uint[count];
+
+        for (uint i = 0; i < count; i++)
+        {
+            source[i] = i;
+        }
+
+        byte[] output = new byte[source.Length * 4];
+
+        StreamVByte.Encode(source, output);
+
+        var decoded = new uint[source.Length];
+
+        StreamVByte.Decode(output, decoded);
+
+        Assert.Equal(source, decoded);
+    }
+}

--- a/StreamVByte.Tests/Usings.cs
+++ b/StreamVByte.Tests/Usings.cs
@@ -1,1 +1,0 @@
-global using Xunit;


### PR DESCRIPTION
This PR adds the first test case that can be used to verify the tail handling, when implemented. 

@neon-sunset Let me know if you're still working on this project and if you need any help completing the implementation.